### PR TITLE
Changed code to accommodate MongoDB's ObjectID

### DIFF
--- a/lib/run-time/feathers/convert-args-to-feathers.js
+++ b/lib/run-time/feathers/convert-args-to-feathers.js
@@ -3,6 +3,14 @@ const merge = require('lodash.mergewith');
 const convertArgsToParams = require('./convert-args-to-params');
 
 module.exports = function convertArgsToFeathers(args, moreParams = []) {
+  // GraphQL's `arg` is created with Object.create(null) https://github.com/graphql/express-graphql/issues/177
+  // Neither args nor objects within args have Object's prototype.
+  // `mergewith` conscientiously retains this, just as it retains ObjectID objects being instances of ObjectID.
+  // However some DBs, e.g. NeDB, expect their object params to inherit from Object.
+  // We therefore have to convert args so it and its inner objects inherit from Object.
+  // The stringify/parse is safe enough as args is derived from the string params to a GraphQL's type.
+  args = JSON.parse(JSON.stringify(args));
+
   moreParams = Array.isArray(moreParams) ? moreParams : [moreParams];
 
   const feathersParams = merge(

--- a/lib/run-time/feathers/convert-args-to-feathers.js
+++ b/lib/run-time/feathers/convert-args-to-feathers.js
@@ -1,11 +1,40 @@
 
+const merge = require('lodash.mergewith');
+const convertArgsToParams = require('./convert-args-to-params');
+
+module.exports = function convertArgsToFeathers(args, moreParams = []) {
+  moreParams = Array.isArray(moreParams) ? moreParams : [moreParams];
+
+  const feathersParams = merge(
+    { query: args.query || {} }, args.params || {}, { graphql: true }, ...moreParams, customizer // { query } must be defined.
+  )
+  return convertArgsToParams(feathersParams);
+};
+
+function customizer(objValue, srcValue, key, obj, src, stack) {
+  return undefined; // Comment out to enable customization function.
+
+  if (typeof srcValue === 'object') {
+    if (srcValue instanceof ObjectID) {
+      return new ObjectID(srcValue.id);}
+  }
+
+  return undefined;
+}
+
+/*
 const deepMerge = require('deepmerge');
 const convertArgsToParams = require('./convert-args-to-params');
 
 module.exports = function convertArgsToFeathers(args, moreParams = []) {
   moreParams = Array.isArray(moreParams) ? moreParams : [moreParams];
 
-  return convertArgsToParams(deepMerge.all(
+  let x = convertArgsToParams(deepMerge.all(
     [ { query: args.query || {} }, args.params || {}, { graphql: true }].concat(moreParams) // { query } must be defined.
   ));
+  if (moreParams.query) {
+    x.query = Object.assign(x.query, moreParams.query)
+  }
+  return x;
 };
+ */

--- a/lib/run-time/feathers/convert-args-to-feathers.js
+++ b/lib/run-time/feathers/convert-args-to-feathers.js
@@ -21,20 +21,3 @@ function customizer(objValue, srcValue, key, obj, src, stack) {
 
   return undefined;
 }
-
-/*
-const deepMerge = require('deepmerge');
-const convertArgsToParams = require('./convert-args-to-params');
-
-module.exports = function convertArgsToFeathers(args, moreParams = []) {
-  moreParams = Array.isArray(moreParams) ? moreParams : [moreParams];
-
-  let x = convertArgsToParams(deepMerge.all(
-    [ { query: args.query || {} }, args.params || {}, { graphql: true }].concat(moreParams) // { query } must be defined.
-  ));
-  if (moreParams.query) {
-    x.query = Object.assign(x.query, moreParams.query)
-  }
-  return x;
-};
- */

--- a/lib/run-time/feathers/convert-args-to-params.js
+++ b/lib/run-time/feathers/convert-args-to-params.js
@@ -1,5 +1,32 @@
 
+// Replace all prop names starting with '__' with ones starting with '$'
+const traverse = require('traverse');
+
 module.exports = function convertArgsToParams(obj) {
+  if (obj === null || obj === undefined) return obj;
+
+  const traverser = traverse(obj);
+  const paths = traverser.paths();
+
+  for (let i = paths.length - 1; i >= 0; i--) {
+    const path = paths[i];
+    const key = path.slice(-1)[0]
+
+    if (key && key.substr(0, 2) === '__') {
+      const $path = [].concat(path.slice(0, -1), `$${key.substr(2)}`);
+      traverser.set($path, traverser.get(path));
+      traverser.set(path, undefined);
+    }
+  }
+
+  traverser.forEach(function (node) {
+    if (node === undefined) {
+      this.remove();
+    }
+  });
+
+  return obj;
+
   return (obj === null || obj === undefined)
     ? obj
     : JSON.parse(JSON.stringify(obj).replace(/__/g, '$'));

--- a/lib/run-time/feathers/convert-args-to-params.js
+++ b/lib/run-time/feathers/convert-args-to-params.js
@@ -14,6 +14,10 @@ module.exports = function convertArgsToParams(obj) {
 
     if (key && key.substr(0, 2) === '__') {
       const $path = [].concat(path.slice(0, -1), `$${key.substr(2)}`);
+      // Our own rtns, though faster, are more likely to have a bug
+      // setByPath(obj, $path, getByPath(obj, path));
+      // deleteByPath(obj, path);
+
       traverser.set($path, traverser.get(path));
       traverser.set(path, undefined);
     }
@@ -27,3 +31,48 @@ module.exports = function convertArgsToParams(obj) {
 
   return obj;
 };
+
+/*
+function getByPath(obj, path) {
+  return path.reduce(
+    (obj1, part) => (typeof obj1 === 'object' ? obj1[part] : undefined),
+    obj
+  );
+}
+
+function setByPath(obj, parts, value) {
+  const lastIndex = parts.length - 1;
+
+  return parts.reduce(
+    (obj1, part, i) => {
+      if (i !== lastIndex) {
+        if (!obj1.hasOwnProperty(part) || typeof obj1[part] !== 'object') {
+          obj1[part] = {};
+        }
+        return obj1[part];
+      }
+
+      obj1[part] = value;
+      return obj1;
+    },
+    obj
+  );
+}
+
+function deleteByPath(obj, parts) {
+  const nonLeafLen = parts.length - 1;
+
+  for (let i = 0; i < nonLeafLen; i++) {
+    let part = parts[i];
+    if (!(part in obj)) { return; }
+
+    obj = obj[part];
+
+    if (typeof obj !== 'object' || obj === null) {
+      throw new errors.BadRequest(`Path '${path}' does not exist. (convert-args-to-params)`);
+    }
+  }
+
+  delete obj[parts[nonLeafLen]];
+}
+*/

--- a/lib/run-time/feathers/convert-args-to-params.js
+++ b/lib/run-time/feathers/convert-args-to-params.js
@@ -26,8 +26,4 @@ module.exports = function convertArgsToParams(obj) {
   });
 
   return obj;
-
-  return (obj === null || obj === undefined)
-    ? obj
-    : JSON.parse(JSON.stringify(obj).replace(/__/g, '$'));
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -582,11 +582,6 @@
         "es5-ext": "0.10.35"
       }
     },
-    "dataloader-align-results": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/dataloader-align-results/-/dataloader-align-results-0.4.0.tgz",
-      "integrity": "sha512-J4rD39yXeb9xRs5tkMIRadk1Wq02UN/3YjL6XVJ4WAqzvtrmaYw/qfeZVEQUglCSHi6ntAfkj3+45jMqcu2aWw=="
-    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -640,7 +635,8 @@
     "deepmerge": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
-      "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
+      "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==",
+      "dev": true
     },
     "default-require-extensions": {
       "version": "1.0.0",
@@ -2133,6 +2129,11 @@
         "lodash.isarguments": "3.1.0",
         "lodash.isarray": "3.0.4"
       }
+    },
+    "lodash.mergewith": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
     },
     "lodash.omit": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@feathers-plus/common": "0.1.0",
     "@feathersjs/errors": "3.2.0",
     "debug": "3.1.0",
-    "deepmerge": "1.5.2",
     "feathers-hooks-common": "3.7.3",
     "graphql": "0.11.6",
     "graphql-tools": "2.0.0",
@@ -61,7 +60,9 @@
     "join-monster": "2.0.15",
     "join-monster-graphql-tools-adapter": "0.0.2",
     "lodash": "4.17.4",
-    "mongo-sql": "4.0.2"
+    "lodash.mergewith": "4.6.0",
+    "mongo-sql": "4.0.2",
+    "traverse": "0.6.6"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
- convert-args-to-feathers now uses lodash.mergewith instead of deepmerge,
  as mergewith retains 'instance of ObjectID' for ObjectID objects.
- lodash.merge may have been sufficient as the customizer for mergewith
  is no-op'ed. It however has code to explicitly reconstruct an ObjectID
  object. This may be needed based on test results, and it can be
  expanded for other similar situations.
- convert-args-to-parms converts prop names starting with __ to ones starting
  with $, e.g. __sort to $sort. The previous code lost 'instance of ObjectID'
  for ObjectID objects. The new code does not, though it takes longer to execute.