### PR TITLE
Added to feathers-batch-loader an option to limit the number of keys read.

### DIFF
--- a/lib/run-time/feathers/feathers-batch-loader.js
+++ b/lib/run-time/feathers/feathers-batch-loader.js
@@ -41,10 +41,11 @@ function feathersBatchLoaderInit(logger1) {
       Return serialized key from record, identical to that produced by serializeBatchLoaderKey1.
       Function - record => serialized key
       String - Converts to record => record[serializeRecordKey1].toString();
-  @param {Number} max - Maximum number of items in the cache. Will use LRU cache.
   @param {Promise} getRecords - Feathers call to read records given [keys] from BatchLoader.
       Can return a '.get()' object or array, else a paginated or non-paginated '.find()' object.
       An error is caught and processed as an empty array.
+  @params {Number} maxBatchSize - Maximum number of keys `getRecords` is called with.
+  @param {Number} maxCacheSize - Maximum number of items in the cache. Will use LRU cache.
   @param {String|Function} serializeBatchLoaderKey1 -
       Serialize key from BatchLoader.load(), identical to that produced by serializeRecordKey1.
       Function - key => serialized key e.g. '1' or '{"name":"a","age":20}'
@@ -52,7 +53,7 @@ function feathersBatchLoaderInit(logger1) {
  */
 
 function feathersBatchLoader(
-  resolverName, graphqlType, serializeRecordKey, getRecords, max, serializeBatchLoaderKey1
+  resolverName, graphqlType, serializeRecordKey, getRecords, maxBatchSize, maxCacheSize, serializeBatchLoaderKey1
 ) {
   debug(`feathersBatchLoader entered. "${resolverName}" "${graphqlType}"`);
   
@@ -62,7 +63,8 @@ function feathersBatchLoader(
   return new BatchLoader(
     batchLoaderFunc(graphqlType, serializeRecordKey, getRecords), {
       cacheKeyFn: serializeBatchLoaderKey,
-      cacheMap: typeof max === 'number' ? cache({ max }) : undefined,
+      cacheMap: typeof maxCacheSize === 'number' ? cache({ maxCacheSize }) : undefined,
+      maxBatchSize: typeof maxBatchSize === 'number' ? maxBatchSize : undefined,
     }
   );
 }


### PR DESCRIPTION
- NOTE This commit changes the signature of feathers-batch-loader. That's OK as
  the func is being used only with private projects.
- The maxc number of keys passed to BatchLoader func can now be controlled.